### PR TITLE
Converts one-way latency values to milliseconds if bucket-width is provided

### DIFF
--- a/react/src/GraphDataStore.js
+++ b/react/src/GraphDataStore.js
@@ -425,6 +425,7 @@ module.exports = {
                     }
                     let row = pruneDatum( datum );
                     row.protocol = datum["ip-transport-protocol"];
+                    row.bucketwidth = datum["sample-bucket-width"];
                     row.ipversion = ipversion;
 
                     dataReqCount++;
@@ -446,6 +447,7 @@ module.exports = {
         if ( data !== null ) {
             let direction = datum.direction;
             let protocol = datum.protocol;
+            let bucketwidth = datum.bucketwidth;
             let row = datum;
             row.eventType = eventType;
             row.data = data;
@@ -712,6 +714,7 @@ module.exports = {
             let eventType = datum.eventType;
             let direction = datum.direction;
             let protocol = datum.protocol;
+            let bucketwidth = datum.bucketwidth;
             if ( eventType == "failures" ) {
                 return true;
             }
@@ -755,6 +758,9 @@ module.exports = {
                 let value = val["val"];
                 if ( eventType == 'histogram-owdelay') {
                     value = val["val"].minimum;
+                    if(bucketwidth){
+                        value = value * bucketwidth / 0.001; //convert to milliseconds
+                    }
                 } else if ( eventType == 'histogram-rtt' ) {
                     value = val["val"].minimum;
                 } else if ( eventType == 'packet-count-lost' ) {


### PR DESCRIPTION
Fixes issue where latency values are displayed incorrectly if a bucket-width is given AND it is a value other than .001. See issue for details. This fix just grabs the field if present and does the math to always convert o milliseconds.

A good test case is the graph here: http://ps-dashboard.es.net/perfsonar-graphs/?source=albq-owamp.es.net&dest=ameslab-owamp.es.net&displaysetdest=ameslab&url=http://albq-pt1.es.net:8085/esmond/perfsonar/archive/&reverseurl=http://ameslab-pt1.es.net:8085/esmond/perfsonar/archive/&displaysetsrc=albq#start=1535125010&end=1535729810&summaryWindow=3600&timeframe=1w

On a graph without the fix, you will see latency values of ~180ms until Aug 29th at which point the bucket-width was removed from the test spec and it starts showing the correct value of ~18ms. On a graph with the fix, you will see a consistent value of around ~18ms for the entire time period.
